### PR TITLE
Patch issue with sphinx>3/docutls>0.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @melund @jakirkham
+* @jakirkham @melund

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham
+* @melund @jakirkham

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About cloud_sptheme
-===================
+About cloud_sptheme-feedstock
+=============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cloud_sptheme-feedstock/blob/main/LICENSE.txt)
 
 Home: https://cloud-sptheme.readthedocs.io/en/latest/
 
 Package license: BSD-3-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cloud_sptheme-feedstock/blob/main/LICENSE.txt)
 
 Summary: A nice sphinx theme named 'Cloud', and some related extensions.
 

--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ Feedstock Maintainers
 =====================
 
 * [@jakirkham](https://github.com/jakirkham/)
+* [@melund](https://github.com/melund/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/0003-fix-pycompat-warning.patch
+++ b/recipe/0003-fix-pycompat-warning.patch
@@ -1,0 +1,28 @@
+From 6156f473323fa96170af6adfb159f33882c1d1e0 Mon Sep 17 00:00:00 2001
+From: Morten Lund <melund@gmail.com>
+Date: Wed, 31 May 2023 14:39:17 +0200
+Subject: [PATCH 1/2] fix pycompat warning
+
+---
+ cloud_sptheme/ext/auto_redirect.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/cloud_sptheme/ext/auto_redirect.py b/cloud_sptheme/ext/auto_redirect.py
+index c8459df..4932f06 100644
+--- a/cloud_sptheme/ext/auto_redirect.py
++++ b/cloud_sptheme/ext/auto_redirect.py
+@@ -55,7 +55,10 @@ import os
+ # site
+ from docutils.nodes import raw
+ from sphinx.builders.html import StandaloneHTMLBuilder
+-from sphinx.util.pycompat import htmlescape
++try:
++    from sphinx.util.pycompat import htmlescape
++except ImportError:
++    from html import escape as htmlescape
+ # pkg
+ from cloud_sptheme import __version__, _root_dir, is_cloud_theme
+ from cloud_sptheme.utils import add_static_file
+-- 
+2.40.1.vfs.0.0
+

--- a/recipe/0004-fix-docutils-0.17-issues-with-toggle-html.patch
+++ b/recipe/0004-fix-docutils-0.17-issues-with-toggle-html.patch
@@ -1,0 +1,24 @@
+From e169206c4f83bd84a4dc84f57ead2baf03b21b44 Mon Sep 17 00:00:00 2001
+From: Morten Lund <melund@gmail.com>
+Date: Wed, 31 May 2023 14:41:39 +0200
+Subject: [PATCH 2/2] fix docutils 0.17 issues with Toggle
+
+---
+ cloud_sptheme/themes/cloud/static/cloud.js_t | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cloud_sptheme/themes/cloud/static/cloud.js_t b/cloud_sptheme/themes/cloud/static/cloud.js_t
+index e653a4f..879dbbd 100644
+--- a/cloud_sptheme/themes/cloud/static/cloud.js_t
++++ b/cloud_sptheme/themes/cloud/static/cloud.js_t
+@@ -223,6 +223,7 @@
+         }
+ 
+         $(".html-toggle.section > h2, .html-toggle.section > h3, .html-toggle.section > h4, .html-toggle.section > h5, .html-toggle.section > h6").each(init);
++        $("section.html-toggle > h2, section.html-toggle > h3, section.html-toggle > h4, section.html-toggle > h5, section.html-toggle > h6").each(init);
+     });
+ 
+     /*==========================================================================
+-- 
+2.40.1.vfs.0.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,12 @@ source:
   patches:
     - 0001-patch-sphinx-4-support.patch
     - 0002-patch-jinja-markup-deprecation.patch
+    - 0003-fix-pycompat-warning.patch
+    - 0004-fix-docutils-0.17-issues-with-toggle-html.patch
 
 build:
   noarch: python
-  number: 2
+  number: 4
   preserve_egg_dir: true
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,4 +44,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - melund
     - jakirkham

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   noarch: python
-  number: 4
+  number: 3
   preserve_egg_dir: true
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
This patches an issue with the html-toggle element in the theme and docutils>0.15 (sphinx > 3.5). 

We need to patch this because this theme is no longer maintained. 


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
